### PR TITLE
ci: release gperl binaries via goreleaser with build provenance attestations

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,36 @@
+name: Release test
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .goreleaser.yml
+      - .github/workflows/release-test.yml
+  pull_request:
+    paths:
+      - .goreleaser.yml
+      - .github/workflows/release-test.yml
+permissions:
+  contents: read
+jobs:
+  release-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser (dry-run)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --skip=publish --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The released binaries embed internal/perl.go and stdlib.zip, both
+      # sourced from perl-wasm releases — refuse to release unless they still
+      # match the upstream attestations.
+      - name: Verify upstream-sourced files (release attestation)
+        run: make verify
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.apk
+            dist/checksums.txt

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ profile.cov
 go.work
 go.work.sum
 
+# GoReleaser output
+dist/
+
 # env file
 .env
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,56 @@
+---
+version: 2
+project_name: gperl
+
+builds:
+  - main: ./cmd/gperl
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - LICENSE-ARTISTIC
+      - LICENSE-GPL
+      - README.md
+
+nfpms:
+  - file_name_template: >-
+      {{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}
+    homepage: https://github.com/goccy/go-perl
+    maintainer: goccy
+    description: Perl 5 in pure Go - embed and run Perl anywhere Go runs
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  prerelease: auto


### PR DESCRIPTION
## Summary

Adds a release pipeline for the `gperl` CLI, mirroring the setup used in goccy/tobari:

- **`.goreleaser.yml`** — builds `cmd/gperl` (CGO_ENABLED=0, `-s -w`) for darwin/linux/windows × amd64/arm64, packages tar.gz/zip archives (with the three license files and README) plus deb/rpm/apk, and generates `checksums.txt`.
- **`.github/workflows/release.yml`** — on `v*` tag push: first re-verifies `internal/perl.go` and `stdlib.zip` against their upstream perl-wasm release attestations (`make verify`), then runs goreleaser to publish the GitHub release with all assets, and finally attests every asset (archives, packages, checksums) with `actions/attest-build-provenance`, so consumers can `gh attestation verify` the downloaded binaries.
- **`.github/workflows/release-test.yml`** — snapshot dry-run of the goreleaser config on PRs/pushes that touch it.
- `.gitignore` — ignore goreleaser's `dist/` output.

## Test plan

- [x] `goreleaser release --snapshot --skip=publish --clean` locally: all 6 targets build, archives + deb/rpm/apk + checksums produced.
- [x] Smoke-tested the darwin/arm64 snapshot binary: `gperl run -e 'print "hello from $^V\n"'` → `hello from v5.44.0`.
- [ ] Real release run happens on the first `v*` tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
